### PR TITLE
fixed abspath() when called via 'misc/build.sh'

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ function abspath() {
 OS_NAME=$(uname -s)
 
 # physical location of this script, and the config
-self=$(abspath $0)
+self=$(abspath ./$0)
 CFGFILE=$(dirname $self)/build.cfg
 
 # location of the patmos-chrpath script


### PR DESCRIPTION
Using bash, ./misc/build.sh worked while misc/build.sh produced a broken 2-line
return value from abspath() for $self.
