### PR TITLE
Unset GREP_OPTIONS at the start of the build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,9 @@ OS_NAME=$(uname -s)
 # avoid changing into CDPATH directories
 unset CDPATH
 
+# Prevent custom GREP options from breaking the build
+unset GREP_OPTIONS
+
 # physical location of this script, and the config
 self=$(abspath $0)
 CFGFILE=$(dirname $self)/build.cfg


### PR DESCRIPTION
Custom grep options set in the environment variables can break the build, e.g. note the line number (-n) in the following output

```
 ===== Processing 'gold' =====
 ===== Cloning from 2:git@github.com:t-crest/patmos-gold.git =====
Cloning into /home/jamie/patmos/patmos-misc/gold...
ssh: connect to host 2 port 22: Invalid argument
fatal: The remote end hung up unexpectedly
```
