### PR TITLE
build.sh: user friendlier default behavior

### DIFF
--- a/build.cfg.dist
+++ b/build.cfg.dist
@@ -1,6 +1,9 @@
 
-# List of targets to build by default
-ALLTARGETS="gold llvm newlib compiler-rt pasim bench poseidon aegean"
+# List of targets to build by default, developers may set this to $ALLTARGETS
+# or a subset of interesting tools
+BUILDSH_TARGETS="gold llvm newlib compiler-rt pasim poseidon aegean"
+#BUILDSH_TARGETS=$ALLTARGETS
+#BUILDSH_TARGETS="llvm pasim"
 
 # Root directory for all repositories
 ROOT_DIR=$(pwd)


### PR DESCRIPTION
build.sh has become the central construction tool for the Patmos toolchain and hardware. @rbscloud remarked that building bench has become quite the burden for a new user, who wants to try Patmos.

This change affects the default build targets and how they are overridden in build.cfg. It also makes -a an option to build _all the targets_.

Note: It is currently assumed that everyone creates a build.cfg from the template.
