### PR TITLE
buildbot: aegean and (future) codebases support

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -51,15 +51,33 @@ c['slavePortnum'] = config.getint('ports','slave-port')
 
 ####### CHANGESOURCES
 
-repos = { 'llvm'  : get_option(config,'repositories','llvm','https://github.com/t-crest/patmos-llvm.git'),
-          'clang' : get_option(config,'repositories','clang','https://github.com/t-crest/patmos-clang.git'),
-          'crt'   : get_option(config,'repositories','crt','https://github.com/t-crest/patmos-compiler-rt.git'),
-          'newlib': get_option(config,'repositories','newlib','https://github.com/t-crest/patmos-newlib.git'),
-          'gold'  : get_option(config,'repositories','gold','https://github.com/t-crest/patmos-gold.git'),
-          'patmos': get_option(config,'repositories','patmos','https://github.com/t-crest/patmos.git'),
-          'bench' : get_option(config,'repositories','benchmarks','http://github.com/t-crest/patmos-benchmarks.git'),
-          'misc'  : get_option(config,'repositories','misc','http://github.com/t-crest/patmos-misc.git'),
-          'hello' : get_option(config,'repositories','hello-wcet','http://github.com/alexjordan/hello-wcet.git') }
+repos = { 'llvm'     : get_option(config,'repositories','llvm','https://github.com/t-crest/patmos-llvm.git'),
+          'clang'    : get_option(config,'repositories','clang','https://github.com/t-crest/patmos-clang.git'),
+          'crt'      : get_option(config,'repositories','crt','https://github.com/t-crest/patmos-compiler-rt.git'),
+          'newlib'   : get_option(config,'repositories','newlib','https://github.com/t-crest/patmos-newlib.git'),
+          'gold'     : get_option(config,'repositories','gold','https://github.com/t-crest/patmos-gold.git'),
+          'patmos'   : get_option(config,'repositories','patmos','https://github.com/t-crest/patmos.git'),
+          'bench'    : get_option(config,'repositories','benchmarks','http://github.com/t-crest/patmos-benchmarks.git'),
+          'misc'     : get_option(config,'repositories','misc','http://github.com/t-crest/patmos-misc.git'),
+          'poseidon' : get_option(config,'repositories','poseidon','http://github.com/t-crest/poseidon.git'),
+          'argo'     : get_option(config,'repositories','argo','http://github.com/t-crest/argo.git'),
+          'aegean'   : get_option(config,'repositories','aegean','http://github.com/t-crest/aegean.git'),
+          'hello'    : get_option(config,'repositories','hello-wcet','http://github.com/alexjordan/hello-wcet.git') }
+
+#### Codebases (Buildbot 0.8.7+, tested with 0.8.9)
+# XXX Enable in the future (requires the new Git Source Step and codebases definitions throughout this file)
+#rev_repos = dict((v,k) for k,v in repos.iteritems())
+#
+#def codebaseGenerator(chdict):
+#    return rev_repos[chdict['repository']]
+#
+#c['codebaseGenerator'] = codebaseGenerator
+#
+## build all_codebases dict like this:
+## {"llvm": {"repository": repos['llvm']},
+##  "misc": {"repository": repos['misc']},
+##  ... }
+#all_codebases = { k: {"repository": v} for k,v in repos.items() }
 
 # the 'change_source' setting tells the buildmaster how it should find out
 # about source code changes. We watch all github repos from the patmos
@@ -81,7 +99,9 @@ for name,repo in repos.items():
 
 from buildbot.process.factory import BuildFactory
 from buildbot.process.properties import WithProperties
+#XXX Enable new Source Step with new buildbot version on master
 from buildbot.steps.source import Git
+#from buildbot.steps.source.git import Git
 from buildbot.steps.shell import ShellCommand, Configure, Compile, Test
 from buildbot.steps.slave import MakeDirectory
 from buildbot.steps.transfer import DirectoryUpload, FileUpload
@@ -119,10 +139,13 @@ def get_install_dir(workdir, shellAbsPath = False):
 
 #
 # Steps for our builds
-def cmds_git(url, workdir = 'build', mode = 'update', name = '', cleanRepoCheck = is_full_build):
+# XXX With new Git Source Step and codebases, set mode to 'incremental' (behavior same as current 'update')
+def cmds_git(reponame, workdir = 'build', mode = 'update', cleanRepoCheck = is_full_build):
    "Return command list for cloning and (for full builds) cleaning a repo"
    steps = []
-   steps.append (Git(url, description = "update %s" % name, mode = mode, workdir = workdir, doStepIf = lambda s : do_fetch_repo(s,name)))
+   steps.append (Git(repos[reponame], description = "update %s" % reponame,
+       #codebase=reponame,
+       mode = mode, workdir = workdir, doStepIf = lambda s : do_fetch_repo(s,reponame)))
    if cleanRepoCheck:
       steps.append (ShellCommand(name = "clean-repo", command = "git clean -dfx", workdir = workdir, doStepIf = cleanRepoCheck))
    return steps
@@ -183,8 +206,8 @@ def build_llvm(workdir='build'):
    steps.append (ShellCommand(name="installclean", description="cleaning install/", descriptionDone="clean install/",
                               command = "rm -fr %s/*" % get_install_dir(workdir, shellAbsPath = True), workdir = workdir,
                               doStepIf = is_clean_install_dir))
-   steps.extend (cmds_git(repos['llvm'], workdir = workdir, name='llvm'))
-   steps.extend (cmds_git(repos['clang'], workdir = "%s/tools/clang" % workdir, name='clang',cleanRepoCheck = lambda s: False))
+   steps.extend (cmds_git('llvm', workdir = workdir))
+   steps.extend (cmds_git('clang', workdir = "%s/tools/clang" % workdir, cleanRepoCheck = lambda s: False))
    steps.extend (cmds_cmake(workdir = workdir, cmakeopts = "-DBUILD_SHARED_LIBS=ON -DLLVM_TARGETS_TO_BUILD=all", timeout = 7200))
    steps.append (Test(command = 'make check-all', workdir = builddir) ) # FIXME refactor properly)
    steps.append (ShellCommand(name="install platin", command = "bash install.sh -i %s" % get_install_dir(platindir, shellAbsPath = True),
@@ -194,7 +217,7 @@ def build_llvm(workdir='build'):
 #
 # compiler-rt build factory
 def build_crt(workdir='build'):
-   steps = cmds_git(repos['crt'], workdir = workdir)
+   steps = cmds_git('crt', workdir = workdir)
    cmakeopts = "-DCMAKE_TOOLCHAIN_FILE=../cmake/patmos-clang-toolchain.cmake -DCMAKE_C_FLAGS=-DCRT_NO_INLINE_ASM"
    steps.extend (cmds_cmake (cmakeopts = cmakeopts, workdir = workdir))
    return steps
@@ -202,7 +225,7 @@ def build_crt(workdir='build'):
 #
 # pasim build factory (workdir = patmos checkout)
 def build_pasim(workdir='build'):
-   steps = cmds_git(repos['patmos'], workdir = workdir)
+   steps = cmds_git('patmos', workdir = workdir)
    steps.extend (cmds_cmake (name="simulator",workdir = "%s/simulator" % workdir, test=True) )
    steps.extend (cmds_cmake (name="ctools",workdir = "%s/tools/c" % workdir) )
    steps.extend ([ Compile(name = "make-emulator", command = "make patsim && make emulator", workdir = workdir),
@@ -212,7 +235,7 @@ def build_pasim(workdir='build'):
 #
 # newlib build factory
 def build_newlib(workdir='build'):
-   steps = cmds_git(repos['newlib'], workdir = workdir)
+   steps = cmds_git('newlib', workdir = workdir)
    configopts = ("--target=patmos-unknown-unknown-elf "
                  "AR_FOR_TARGET=%(prefix_cmd)s/bin/llvm-ar "
                  "RANLIB_FOR_TARGET=%(prefix_cmd)s/bin/llvm-ranlib "
@@ -225,7 +248,7 @@ def build_newlib(workdir='build'):
 #
 # gold build factory
 def build_gold(workdir='build'):
-   steps = cmds_git(repos['gold'], workdir = workdir)
+   steps = cmds_git('gold', workdir = workdir)
    steps.extend (cmd_confmake (configopts = "--program-prefix=patmos- --enable-gold=yes --enable-ld=no",buildtarget = "all-gold",installtarget = "install-gold", workdir = workdir))
    return steps
 
@@ -250,7 +273,7 @@ class BenchStats(ShellCommand):
 #
 # patmos-benchmarks build factory
 def build_bench(workdir='build'):
-   steps = cmds_git(repos['bench'])
+   steps = cmds_git('bench')
    opts = "-DCMAKE_TOOLCHAIN_FILE=../cmake/patmos-clang-toolchain.cmake -DENABLE_TESTING=true -DENABLE_CTORTURE=true"
    steps.extend (cmds_cmake (cmakeopts = opts, workdir = workdir, install=False, test=True, timeout=3600) )
    return steps
@@ -258,20 +281,27 @@ def build_bench(workdir='build'):
 #
 # build_sh_tools factory: build (all) tools through build.sh script
 def build_sh_tools(workdir='build'):
-   steps = cmds_git(repos['misc'], workdir=os.path.join(workdir,'misc'))
+   build_cfg = '\n'.join([('BUILD_EMULATOR=false')]) + '\n'
+   # XXX pull changes for all repos iso. using build.sh -u
+   steps = cmds_git('misc', workdir=os.path.join(workdir,'misc'))
    steps.append (ShellCommand(name="installclean", description="cleaning install/", descriptionDone="clean install/",
                               command = "rm -fr %s/*" % get_install_dir(workdir, shellAbsPath = True), workdir = workdir,
                               doStepIf = is_clean_install_dir))
+   # create the build.cfg file in misc/ with build settings
+   steps.append (ShellCommand(name="create-build_cfg", description="configuring build.sh",
+      command='cat - > misc/build.cfg', initialStdin = build_cfg))
+   # call build.sh for each of the required tools
    for tool in ['gold', 'llvm', 'newlib', 'compiler-rt', 'pasim']:
       steps.append (Compile(name="build.sh-%s" % tool,
-         command = "misc/build.sh -i %s -u %s" % (get_install_dir(workdir),tool),
-         workdir = workdir))
+          description="build.sh'ing %s" % tool, descriptionDone="built %s" % tool,
+          command = "misc/build.sh -i %s -u %s" % (get_install_dir(workdir),tool),
+          workdir = workdir))
    return steps
 
 #
 # build_hello factory: build simple platin/WCET program and test with AbsInt's a3
 def build_hello(workdir='build'):
-   steps = cmds_git(repos['hello'])
+   steps = cmds_git('hello')
    steps.append (Compile(command = "make all", workdir = workdir) )
    steps.append (Test(command = 'make check', workdir = workdir) )
    return steps
@@ -279,15 +309,38 @@ def build_hello(workdir='build'):
 #
 # build_platin_test: build subset of benchmarks test to validate platin
 def build_platin_test(workdir='work'):
-   steps = cmds_git(repos['bench'], workdir = workdir)
+   steps = cmds_git('bench', workdir = workdir)
    opts = "-DCMAKE_TOOLCHAIN_FILE=../cmake/patmos-clang-toolchain.cmake -DENABLE_TESTING=true -DENABLE_CTORTURE=false -DENABLE_PLATIN_TESTS=true"
    steps.extend (cmds_cmake_test (cmakeopts = opts, workdir = workdir, subdir = 'tests', install=False, timeout=3600) )
    return steps
 
 #
+# build_aegean: build the uber platform
+def build_aegean(workdir='work'):
+   steps = []
+   # all repos required for the aegean platform build (toolchain is installed)
+   for repo in ['misc', 'patmos', 'poseidon', 'aegean']:
+      steps.extend (cmds_git(repo, workdir=os.path.join(workdir,repo)))
+   # don't force GitMaster update here, argo has the development branch
+   steps.extend (cmds_git('argo', workdir=os.path.join(workdir,'argo')))
+   # build through build.sh (currently only poseidon needs to be built and installed)
+   for tool in ['poseidon', 'aegean']:
+      steps.append (Compile(name="build.sh-%s" % tool,
+          description = "building %s" % tool, descriptionDone = "built %s" % tool,
+          command = "misc/build.sh -i %s %s" % (get_install_dir(workdir),tool), workdir = workdir))
+   aegeandir = os.path.join(workdir, 'aegean')
+   steps.append (Test(name = 'poseidon', description = 'poseidon test', descriptionDone = 'poseidon test',
+       command = "make -C build test", workdir = os.path.join(workdir, 'poseidon') ) )
+   steps.append (Test(name = 'aegeantest', description = 'aegean test', descriptionDone = 'aegean test',
+       command = "make buildbot-test", workdir = aegeandir ) )
+   steps.append (Test(name = 'argotest', description = 'argo test', descriptionDone = 'argo test',
+       command = "./buildbot.sh", workdir = os.path.join(workdir, 'argo', 'sim') ) )
+   return steps
+
+#
 # patmos synthesis build factory
 def build_patmos_synth(qproj='altde2-70', workdir='build', app = 'test'):
-   steps = cmds_git(repos['patmos'],workdir = workdir)
+   steps = cmds_git('patmos',workdir = workdir)
    steps.append (Compile(name="make-tools",command = "make tools",workdir = workdir))
    steps.append (Compile(name="make-gen",command = "make gen QPROJ=%s" % qproj, workdir = workdir))
    steps.append (Compile(name="make-synth",command = "make synth QPROJ=%s" % qproj,workdir = workdir))
@@ -330,6 +383,10 @@ mainbuilders = { "buildllvm"   : build_llvm(),
 build_sh_builders = { "buildshtools"    : build_sh_tools(),
                       "buildhello"      : build_hello(),
                       "buildplatintest" : build_platin_test() }
+
+platform_builders = { "buildaegean" : build_aegean() }
+
+nonmainbuilders = {k:v for d in (build_sh_builders, platform_builders) for k, v in d.iteritems()}
 
 # Architectures
 architectures = [ "linux-i686", "linux-x64" ]
@@ -386,7 +443,7 @@ c['builders'] = []
 builders_add(c['builders'], slaves_main, mainbuilders, suffix="")
 
 # testing slaves
-builders_add(c['builders'], slaves_testing, build_sh_builders, suffix="", path_in_env=True)
+builders_add(c['builders'], slaves_testing, nonmainbuilders, suffix="", path_in_env=True)
 
 # architecture slaves
 for arch in architectures:
@@ -397,10 +454,10 @@ builders_add(c['builders'], slaves_synth, synthbuilders, suffix="")
 
 # prioritize main toolchain builders
 def builders_prioritize(buildmaster, builders):
-    builderPriorities = {}
+    builderPriorities = { "buildshtools" : 1 }
     for idx, key in enumerate(mainbuilders.keys()):
        builderPriorities[key] = idx
-    builders.sort(key=lambda b: builderPriorities.get(b.name, 0))
+    builders.sort(key=lambda b: builderPriorities.get(b.name, 1))
     return builders
 c['prioritizeBuilders'] = builders_prioritize
 
@@ -484,25 +541,36 @@ if slaves_main:
 # Builders for non-toolchain testing
 #
 if slaves_testing:
-   # Incremental build (daily)
+   # Nightly build (non-clean)
    c['schedulers'].append(timed.Nightly(name = 'nightly_tools',
                                         branch = 'master',
                                         builderNames = ["buildshtools"],
-                                        hour = 15,
+                                        #codebases=all_codebases, onlyIfChanged = True,
+                                        hour = 0,
+                                        minute = 0))
+
+   # Nightly build (non-clean)
+   c['schedulers'].append(timed.Nightly(name = 'nightly_platform',
+                                        branch = 'master',
+                                        builderNames = ["buildaegean"],
+                                        #codebases=all_codebases, onlyIfChanged = True,
+                                        hour = 1,
                                         minute = 0))
    # Build depending on tools
    c['schedulers'].append(basic.Dependent(name = 'tools-dependent',
                                           builderNames = ["buildhello", "buildplatintest"],
                                           upstream=c['schedulers'][-1]))
-   # Clean build (weekly)
+   # Weekly build (clean)
    c['schedulers'].append(timed.Nightly(name = 'weekly_tools',
                                         branch = 'master',
-                                        builderNames = ["buildshtools", "buildhello", "buildplatintest"],
-                                        hour = 2,
+                                        builderNames = nonmainbuilders.keys(),
+                                        #codebases=all_codebases,
+                                        hour = 1,
                                         minute = 0,
                                         dayOfWeek=1,
                                         properties = { 'fullBuild' : 'true',
                                                        'cleanInstallDir' : 'true' }))
+
 #
 # Manual schedulers for all builders
 if slaves_main:
@@ -512,7 +580,9 @@ if slaves_main:
       c['schedulers'].append(ForceScheduler(name = "force_"+arch,
                                             builderNames = [ name + "_" + arch for name in archbuilders.keys() ]))
 if slaves_testing:
-   c['schedulers'].append(ForceScheduler(name = "force", builderNames = build_sh_builders.keys()))
+   c['schedulers'].append(ForceScheduler(name = "force_testing",
+      #codebases=all_codebases,
+      builderNames = nonmainbuilders.keys() ))
 
 
 


### PR DESCRIPTION
Using codebases allows the use of multiple source repos in a single builder to
work with incoming changes. This requires a newer buildmaster than currently
available at vmars, so everything is commented out for now.
